### PR TITLE
Fix bug making anyone claims admin

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION is_claims_admin() RETURNS "bool"
   LANGUAGE "plpgsql" 
   AS $$
   BEGIN
-    IF session_user = 'authenticator' THEN
+    IF current_user = 'authenticated' THEN
       --------------------------------------------
       -- To disallow any authenticated app users
       -- from editing claims, delete the following


### PR DESCRIPTION
First off - thanks for this library!

## What kind of change does this PR introduce?

Security fix.

## What is the current behavior?

The `is_claims_admin` function always returns `true`. This allows *any* authenticated user to set claims on their own account. This completely defeats the purpose of this library.

## What is the new behavior?

The `is_claims_admin` function returns `false` when it should.

## Additional context

The `session_user` is always `"postgres"` (the user that was used to establish the connection). I assume `current_user` is what was intended here.

Furthermore, the `current_user` will never have the value `"authenticator"`. However, for authenticated users it will have the value `"authenticated"`.

Since this library is about security, I suggest it comes with a disclaimer saying that this library does **not have any automated tests**, and therefore might not work as intended.
