### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ You can force a refresh of the current session token by calling `supabase.auth.u
 ##### find all users who have `claims_admin` set to `true`
 `select * from auth.users where (auth.users.raw_app_meta_data->'claims_admin')::bool = true;`
 ##### find all users who have a `userlevel` over 100
-`select * from auth.users where (auth.users.raw_app_meta_data->'userleval')::numeric > 100;`
+`select * from auth.users where (auth.users.raw_app_meta_data->'userlevel')::numeric > 100;`
 ##### find all users whose `userrole` is set to `"MANAGER"`
 (note for strings you need to add double-quotes becuase data is data is stored as JSONB)
 `select * from auth.users where (auth.users.raw_app_meta_data->'userrole')::text = '"MANAGER"';`


### PR DESCRIPTION
`userleval` -> `userlevel`

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

`userleval`

## What is the new behavior?

`userlevel`

## Additional context

![зображення](https://user-images.githubusercontent.com/370680/214700446-55ea0e69-87b3-4a3c-b30a-12c05e2fda6d.png)
