### PR TITLE
feat: make service role users admins

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -11,7 +11,10 @@ CREATE OR REPLACE FUNCTION is_claims_admin() RETURNS "bool"
       --------------------------------------------
       IF extract(epoch from now()) > coalesce((current_setting('request.jwt.claims', true)::jsonb)->>'exp', '0')::numeric THEN
         return false; -- jwt expired
-      END IF; 
+      END IF;
+      If current_setting('request.jwt.claims', true)::jsonb->>'role' = 'service_role' THEN
+        RETURN true; -- service role users have admin rights
+      END IF;
       IF coalesce((current_setting('request.jwt.claims', true)::jsonb)->'app_metadata'->'claims_admin', 'false')::bool THEN
         return true; -- user has claims_admin set to true
       ELSE


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

As is, `is_claims_admin()` will not return `true` when called by a user with the `service_role` role type. Given that the service role is intended to bypass all authorization, I think it makes sense to accept calls from `service_role` users as admins.

## What is the new behavior?

Any request with a role of `service_role` in its JWT claims will be accepted as an admin request.