### PR TITLE
Set search_path to empty string to follow security best practices

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -1,5 +1,6 @@
 CREATE OR REPLACE FUNCTION is_claims_admin() RETURNS "bool"
   LANGUAGE "plpgsql" 
+  SET search_path = ''
   AS $$
   BEGIN
     IF session_user = 'authenticator' THEN
@@ -9,13 +10,13 @@ CREATE OR REPLACE FUNCTION is_claims_admin() RETURNS "bool"
       -- block of code and replace it with:
       -- RETURN FALSE;
       --------------------------------------------
-      IF extract(epoch from now()) > coalesce((current_setting('request.jwt.claims', true)::jsonb)->>'exp', '0')::numeric THEN
+      IF extract(epoch from now()) > coalesce((pg_catalog.current_setting('request.jwt.claims', true)::jsonb)->>'exp', '0')::numeric THEN
         return false; -- jwt expired
       END IF;
-      If current_setting('request.jwt.claims', true)::jsonb->>'role' = 'service_role' THEN
+      If pg_catalog.current_setting('request.jwt.claims', true)::jsonb->>'role' = 'service_role' THEN
         RETURN true; -- service role users have admin rights
       END IF;
-      IF coalesce((current_setting('request.jwt.claims', true)::jsonb)->'app_metadata'->'claims_admin', 'false')::bool THEN
+      IF coalesce((pg_catalog.current_setting('request.jwt.claims', true)::jsonb)->'app_metadata'->'claims_admin', 'false')::bool THEN
         return true; -- user has claims_admin set to true
       ELSE
         return false; -- user does NOT have claims_admin set to true
@@ -31,23 +32,25 @@ $$;
 
 CREATE OR REPLACE FUNCTION get_my_claims() RETURNS "jsonb"
     LANGUAGE "sql" STABLE
+    SET search_path = ''
     AS $$
   select 
-  	coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata', '{}'::jsonb)::jsonb
+  	coalesce(nullif(pg_catalog.current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata', '{}'::jsonb)::jsonb
 $$;
 CREATE OR REPLACE FUNCTION get_my_claim(claim TEXT) RETURNS "jsonb"
     LANGUAGE "sql" STABLE
+    SET search_path = ''
     AS $$
   select 
-  	coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata' -> claim, null)
+  	coalesce(nullif(pg_catalog.current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata' -> claim, null)
 $$;
 
 CREATE OR REPLACE FUNCTION get_claims(uid uuid) RETURNS "jsonb"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     DECLARE retval jsonb;
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN '{"error":"access denied"}'::jsonb;
       ELSE
         select raw_app_meta_data from auth.users into retval where id = uid::uuid;
@@ -57,11 +60,11 @@ CREATE OR REPLACE FUNCTION get_claims(uid uuid) RETURNS "jsonb"
 $$;
 
 CREATE OR REPLACE FUNCTION get_claim(uid uuid, claim text) RETURNS "jsonb"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     DECLARE retval jsonb;
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN '{"error":"access denied"}'::jsonb;
       ELSE
         select coalesce(raw_app_meta_data->claim, null) from auth.users into retval where id = uid::uuid;
@@ -71,10 +74,10 @@ CREATE OR REPLACE FUNCTION get_claim(uid uuid, claim text) RETURNS "jsonb"
 $$;
 
 CREATE OR REPLACE FUNCTION set_claim(uid uuid, claim text, value jsonb) RETURNS "text"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN 'error: access denied';
       ELSE        
         update auth.users set raw_app_meta_data = 
@@ -86,10 +89,10 @@ CREATE OR REPLACE FUNCTION set_claim(uid uuid, claim text, value jsonb) RETURNS 
 $$;
 
 CREATE OR REPLACE FUNCTION delete_claim(uid uuid, claim text) RETURNS "text"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN 'error: access denied';
       ELSE        
         update auth.users set raw_app_meta_data = 

--- a/supabase_custom_claims--1.0.sql
+++ b/supabase_custom_claims--1.0.sql
@@ -3,6 +3,7 @@
 
 CREATE OR REPLACE FUNCTION is_claims_admin() RETURNS "bool"
   LANGUAGE "plpgsql" 
+  SET search_path = ''
   AS $$
   BEGIN
     IF session_user = 'authenticator' THEN
@@ -12,10 +13,10 @@ CREATE OR REPLACE FUNCTION is_claims_admin() RETURNS "bool"
       -- block of code and replace it with:
       -- RETURN FALSE;
       --------------------------------------------
-      IF extract(epoch from now()) > coalesce((current_setting('request.jwt.claims', true)::jsonb)->>'exp', '0')::numeric THEN
+      IF extract(epoch from now()) > coalesce((pg_catalog.current_setting('request.jwt.claims', true)::jsonb)->>'exp', '0')::numeric THEN
         return false; -- jwt expired
       END IF; 
-      IF coalesce((current_setting('request.jwt.claims', true)::jsonb)->'app_metadata'->'claims_admin', 'false')::bool THEN
+      IF coalesce((pg_catalog.current_setting('request.jwt.claims', true)::jsonb)->'app_metadata'->'claims_admin', 'false')::bool THEN
         return true; -- user has claims_admin set to true
       ELSE
         return false; -- user does NOT have claims_admin set to true
@@ -31,23 +32,25 @@ $$;
 
 CREATE OR REPLACE FUNCTION get_my_claims() RETURNS "jsonb"
     LANGUAGE "sql" STABLE
+    SET search_path = ''
     AS $$
   select 
-  	coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata', '{}'::jsonb)::jsonb
+  	coalesce(nullif(pg_catalog.current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata', '{}'::jsonb)::jsonb
 $$;
 CREATE OR REPLACE FUNCTION get_my_claim(claim TEXT) RETURNS "jsonb"
     LANGUAGE "sql" STABLE
+    SET search_path = ''
     AS $$
   select 
-  	coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata' -> claim, null)
+  	coalesce(nullif(pg_catalog.current_setting('request.jwt.claims', true), '')::jsonb -> 'app_metadata' -> claim, null)
 $$;
 
 CREATE OR REPLACE FUNCTION get_claims(uid uuid) RETURNS "jsonb"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     DECLARE retval jsonb;
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN '{"error":"access denied"}'::jsonb;
       ELSE
         select raw_app_meta_data from auth.users into retval where id = uid::uuid;
@@ -57,11 +60,11 @@ CREATE OR REPLACE FUNCTION get_claims(uid uuid) RETURNS "jsonb"
 $$;
 
 CREATE OR REPLACE FUNCTION get_claim(uid uuid, claim text) RETURNS "jsonb"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     DECLARE retval jsonb;
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN '{"error":"access denied"}'::jsonb;
       ELSE
         select coalesce(raw_app_meta_data->claim, null) from auth.users into retval where id = uid::uuid;
@@ -71,10 +74,10 @@ CREATE OR REPLACE FUNCTION get_claim(uid uuid, claim text) RETURNS "jsonb"
 $$;
 
 CREATE OR REPLACE FUNCTION set_claim(uid uuid, claim text, value jsonb) RETURNS "text"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN 'error: access denied';
       ELSE        
         update auth.users set raw_app_meta_data = 
@@ -86,10 +89,10 @@ CREATE OR REPLACE FUNCTION set_claim(uid uuid, claim text, value jsonb) RETURNS 
 $$;
 
 CREATE OR REPLACE FUNCTION delete_claim(uid uuid, claim text) RETURNS "text"
-    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = public
+    LANGUAGE "plpgsql" SECURITY DEFINER SET search_path = ''
     AS $$
     BEGIN
-      IF NOT is_claims_admin() THEN
+      IF NOT public.is_claims_admin() THEN
           RETURN 'error: access denied';
       ELSE        
         update auth.users set raw_app_meta_data = 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Security fix.

## What is the current behavior?

Supabase Security Advisor suggests to set `search_path` to an empty string. See:
* #17

## What is the new behavior?

* Added an empty string to every function
* Explicitly set the schema when calling another function 

## Additional context

This pull request includes changes to ensure that all SQL queries explicitly reference the `public` schema and set the search path to an empty string to avoid ambiguity.

See https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0011_function_search_path_mutable

Closes #17
